### PR TITLE
AR6MX: add UART2 support

### DIFF
--- a/arch/arm/boot/dts/imx6qdl-ar6mx.dtsi
+++ b/arch/arm/boot/dts/imx6qdl-ar6mx.dtsi
@@ -352,6 +352,15 @@
 			>;
 		};
 
+	pinctrl_uart2: uart2grp {
+		fsl,pins = <
+			MX6QDL_PAD_EIM_D26__UART2_TX_DATA     0x1b0b1
+			MX6QDL_PAD_EIM_D27__UART2_RX_DATA     0x1b0b1
+			MX6QDL_PAD_EIM_D28__UART2_CTS_B     0x1b0b1
+			MX6QDL_PAD_EIM_D29__UART2_RTS_B     0x1b0b1
+			>;
+		};
+
 	pinctrl_uart4: uart4grp {
 		fsl,pins = <
 			MX6QDL_PAD_KEY_COL0__UART4_TX_DATA  0x1b0b1
@@ -492,6 +501,12 @@
 	status = "okay";
 };
 
+&uart2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_uart2>;
+	fsl,uart-has-rtscts;
+	status = "okay";
+};
 
 &uart4 {
 	pinctrl-names = "default";


### PR DESCRIPTION
Add UART2 pinctrl to imx6qdl-ar6mx.dtsi

Signed-off-by: Frodo Lai <frodo_lai@bcmcom.com>