### PR TITLE
L5.0.0 test merge

### DIFF
--- a/sound/soc/fsl/imx-wm8960.c
+++ b/sound/soc/fsl/imx-wm8960.c
@@ -582,7 +582,7 @@ static int imx_wm8960_probe(struct platform_device *pdev)
 	data->card.dapm_widgets = imx_wm8960_dapm_widgets;
 	data->card.num_dapm_widgets = ARRAY_SIZE(imx_wm8960_dapm_widgets);
 
-#ifdef CONFIG_SND_SOC_Imx_WM8960_ANDROID
+#ifdef CONFIG_SND_SOC_IMX_WM8960_ANDROID
     data->card.set_bias_level = imx_wm8960_set_bias_level;
 #endif
 


### PR DESCRIPTION
Fixed the typo which casues imx_wm8960_set_bias_level not working. (see below)

    Fix typo on Workaround for HDMI mute issue

    Signed-off-by: Frodo Lai <frodo_lai@bcmcom.com>

diff --git a/sound/soc/fsl/imx-wm8960.c b/sound/soc/fsl/imx-wm8960.c
index 75feefe..2e53e00 100644
--- a/sound/soc/fsl/imx-wm8960.c
+++ b/sound/soc/fsl/imx-wm8960.c
@@ -582,7 +582,7 @@ static int imx_wm8960_probe(struct platform_device *pdev)
        data->card.dapm_widgets = imx_wm8960_dapm_widgets;
        data->card.num_dapm_widgets = ARRAY_SIZE(imx_wm8960_dapm_widgets);

-#ifdef CONFIG_SND_SOC_Imx_WM8960_ANDROID
+#ifdef CONFIG_SND_SOC_IMX_WM8960_ANDROID
     data->card.set_bias_level = imx_wm8960_set_bias_level;
 #endif

